### PR TITLE
Flink: Support 'read.split.wait' when streaming read.

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -45,4 +45,10 @@ public class FlinkConfigOptions {
           .longType()
           .defaultValue(-1L)
           .withDescription("Sets steaming read limit per second infer parallelism for source operator.");
+
+  public static final ConfigOption<Long> READ_SPLIT_WAIT_TIME =
+      ConfigOptions.key("read.split.wait")
+          .longType()
+          .defaultValue(-1L)
+          .withDescription("Sets wait time (ms) after every split for read operator.");
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -216,9 +216,13 @@ public class FlinkSource {
         String readerOperatorName = String.format("Iceberg table (%s) reader", table);
 
         long readLimitPerSecond = readableConfig.get(FlinkConfigOptions.READ_LIMIT_PER_SECOND);
+        long readSplitWaitTime = readableConfig.get(FlinkConfigOptions.READ_SPLIT_WAIT_TIME);
 
         return env.addSource(function, monitorFunctionName)
-            .transform(readerOperatorName, typeInfo, StreamingReaderOperator.factory(format, readLimitPerSecond));
+            .transform(
+                readerOperatorName,
+                typeInfo,
+                StreamingReaderOperator.factory(format, readLimitPerSecond, readSplitWaitTime));
       }
     }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -267,7 +267,7 @@ public class TestStreamingReaderOperator extends TableTestBase {
         .buildFormat();
 
     OneInputStreamOperatorFactory<FlinkInputSplit, RowData> factory =
-        StreamingReaderOperator.factory(inputFormat, -1L);
+        StreamingReaderOperator.factory(inputFormat, -1L, -1L);
     OneInputStreamOperatorTestHarness<FlinkInputSplit, RowData> harness = new OneInputStreamOperatorTestHarness<>(
         factory, 1, 1, 0);
     harness.getStreamConfig().setTimeCharacteristic(TimeCharacteristic.ProcessingTime);


### PR DESCRIPTION
Flink: Support 'read.split.wait' when streaming read.